### PR TITLE
Fix category links

### DIFF
--- a/src/components/atoms/CategoryLink.astro
+++ b/src/components/atoms/CategoryLink.astro
@@ -6,8 +6,11 @@ interface Props {
     slug: string;
 }
 
-let { title, slug } = Astro.props;
+const { title, slug } = Astro.props;
 
 ---
 
-<a href=`/jrnl/category/${slug}`><CategoryText title={title}/></a>
+<a href={`/jrnl/category/${slug}`}>
+  <CategoryText title={title} />
+</a>
+


### PR DESCRIPTION
## Summary
- fix `CategoryLink` Astro component

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_686539cfba7c8324a9b43d7a14e48a1a